### PR TITLE
Don't cache exceptions nor WP_Error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+* Bypass the caching operation if a callback either throws an Exception or returns a `WP_Error` object.
+
 ## [1.0.0] - 2018-02-16
 
 Initial public release of the package, including the following functions:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ WP Cache Remember provides the following functions for WordPress:
 * [`remember_site_transient()`](#remember_site_transient)
 * [`forget_site_transient()`](#forget_site_transient)
 
+Each function checks the response of the callback for a `WP_Error` object, ensuring you're not caching temporary errors for long periods of time. PHP Exceptions will also not be cached.
+
 ### wp_cache_remember()
 
 Retrieve a value from the object cache. If it doesn't exist, run the `$callback` to generate and cache the value.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file
  *
- * @package Wp_Cache_Remember
+ * @package SteveGrunwell\WPCacheRemember
  */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the object cache functions.
  *
- * @package Wp_Cache_Remember
+ * @package SteveGrunwell\WPCacheRemember
  */
 
 /**

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -26,6 +26,32 @@ class ObjectCacheTest extends WP_UnitTestCase {
 		$this->assertEquals( $value, wp_cache_get( $key ) );
 	}
 
+	function test_does_not_cache_exceptions() {
+		$key = 'some-cache-key-' . uniqid();
+
+		try {
+			wp_cache_remember( $key, function () {
+				throw new Exception( 'Something went wrong!' );
+			} );
+
+		} catch ( Exception $e ) {
+			$this->assertFalse( wp_cache_get( $key ), 'Expected the exception to not be cached.' );
+			return;
+		}
+
+		$this->fail( 'Did not receive expected exception!' );
+	}
+
+	function test_does_not_cache_wp_errors() {
+		$key = 'some-cache-key-' . uniqid();
+
+		wp_cache_remember( $key, function () {
+			return new WP_Error( 'code', 'Something went wrong!' );
+		} );
+
+		$this->assertFalse( wp_cache_get( $key ), 'Expected the WP_Error to not be cached.' );
+	}
+
 	function test_remember_pulls_from_cache() {
 		$key   = 'some-cache-key-' . uniqid();
 		$value = uniqid();

--- a/tests/test-site-transients.php
+++ b/tests/test-site-transients.php
@@ -26,6 +26,32 @@ class SiteTransientTest extends WP_UnitTestCase {
 		$this->assertEquals( $value, get_site_transient( $key ) );
 	}
 
+	function test_does_not_remember_exceptions() {
+		$key = 'some-cache-key-' . uniqid();
+
+		try {
+			remember_site_transient( $key, function () {
+				throw new Exception( 'Something went wrong!' );
+			} );
+
+		} catch ( Exception $e ) {
+			$this->assertFalse( get_site_transient( $key ), 'Expected the exception to not be cached.' );
+			return;
+		}
+
+		$this->fail( 'Did not receive expected exception!' );
+	}
+
+	function test_does_not_remember_wp_errors() {
+		$key = 'some-cache-key-' . uniqid();
+
+		remember_site_transient( $key, function () {
+			return new WP_Error( 'code', 'Something went wrong!' );
+		} );
+
+		$this->assertFalse( get_site_transient( $key ), 'Expected the WP_Error to not be cached.' );
+	}
+
 	function test_remember_pulls_from_cache() {
 		$key   = 'some-cache-key-' . uniqid();
 		$value = uniqid();

--- a/tests/test-site-transients.php
+++ b/tests/test-site-transients.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the site transient functions.
  *
- * @package Wp_Cache_Remember
+ * @package SteveGrunwell\WPCacheRemember
  */
 
 /**

--- a/tests/test-transients.php
+++ b/tests/test-transients.php
@@ -26,6 +26,32 @@ class TransientTest extends WP_UnitTestCase {
 		$this->assertEquals( $value, get_transient( $key ) );
 	}
 
+	function test_does_not_remember_exceptions() {
+		$key = 'some-cache-key-' . uniqid();
+
+		try {
+			remember_transient( $key, function () {
+				throw new Exception( 'Something went wrong!' );
+			} );
+
+		} catch ( Exception $e ) {
+			$this->assertFalse( get_transient( $key ), 'Expected the exception to not be cached.' );
+			return;
+		}
+
+		$this->fail( 'Did not receive expected exception!' );
+	}
+
+	function test_does_not_remember_wp_errors() {
+		$key = 'some-cache-key-' . uniqid();
+
+		remember_transient( $key, function () {
+			return new WP_Error( 'code', 'Something went wrong!' );
+		} );
+
+		$this->assertFalse( get_transient( $key ), 'Expected the WP_Error to not be cached.' );
+	}
+
 	function test_remember_pulls_from_cache() {
 		$key   = 'some-cache-key-' . uniqid();
 		$value = uniqid();

--- a/tests/test-transients.php
+++ b/tests/test-transients.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the transient functions.
  *
- * @package Wp_Cache_Remember
+ * @package SteveGrunwell\WPCacheRemember
  */
 
 /**

--- a/wp-cache-remember.php
+++ b/wp-cache-remember.php
@@ -33,7 +33,9 @@ if ( ! function_exists( 'wp_cache_remember' ) ) :
 
 		$value = $callback();
 
-		wp_cache_set( $key, $value, $group, $expire );
+		if ( ! is_wp_error( $value ) ) {
+			wp_cache_set( $key, $value, $group, $expire );
+		}
 
 		return $value;
 	}
@@ -85,7 +87,9 @@ if ( ! function_exists( 'remember_transient' ) ) :
 
 		$value = $callback();
 
-		set_transient( $key, $value, $expire );
+		if ( ! is_wp_error( $value ) ) {
+			set_transient( $key, $value, $expire );
+		}
 
 		return $value;
 	}
@@ -135,7 +139,9 @@ if ( ! function_exists( 'remember_site_transient' ) ) :
 
 		$value = $callback();
 
-		set_site_transient( $key, $value, $expire );
+		if ( ! is_wp_error( $value ) ) {
+			set_site_transient( $key, $value, $expire );
+		}
 
 		return $value;
 	}


### PR DESCRIPTION
We should do our best to avoid caching `WP_Error` objects or PHP exceptions, as these are typically not things we want to cache. Explicitly checking for `WP_Error` objects ([via `is_wp_error()`](https://developer.wordpress.org/reference/functions/is_wp_error/) also enables developers to short-circuit the cache, if necessary.

For example, assume we have the following function:

```php
remember_transient( 'some-cache-key', function () {
  $response = wp_remote_get( 'https://example.com' );

  // Something went wrong with the request.
  if ( is_wp_error( $response ) ) {
    return $response;
  } elseif ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
    return new WP_Error( 'api-error', 'Received a non-200 status code.' );
  }

  return wp_remote_retrieve_body( $response );
}, DAY_IN_SECONDS );
```

If the response failed or returned a non-200 status code, that value could be cached for a day; temporary latency, a now-fixed bug, or any other number of reasons could result in stale errors being returned to users.

With this PR, the returned value is run through `is_wp_error()` before being stored in the object cache, transients, or site transients.