### PR TITLE
Loosen Composer requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - php: 7.2
       env: WP_VERSION=trunk
     - php: 7.2
-      env: WP_VERSION=trunk COMPOSER_ARGS="--prefer-lowest"
+      env: WP_VERSION=trunk COMPOSER_LOWEST=1
     - php: 7.2
       env: WP_VERSION=latest RUN_PHPCS=1 RUN_CODE_COVERAGE=1
     - php: 7.1
@@ -39,8 +39,10 @@ before_script:
       composer global require "phpunit/phpunit=4.8.*|5.7.*"
     fi
   - |
-    if [[ ! -z "$COMPOSER_ARGS" ]]; then
-      composer install --prefer-dist --no-suggest --no-autoloader $COMPOSER_ARGS
+    if [[ ${COMPOSER_LOWEST} ]]; then
+      composer update $COMPOSER_ARGS
+    else
+      composer install --prefer-dist --no-suggest --no-autoloader
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - php: 7.2
       env: WP_VERSION=trunk
     - php: 7.2
+      env: WP_VERSION=trunk COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.2
       env: WP_VERSION=latest RUN_PHPCS=1 RUN_CODE_COVERAGE=1
     - php: 7.1
       env: WP_VERSION=latest
@@ -36,7 +38,10 @@ before_script:
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=4.8.*|5.7.*"
     fi
-  - composer install --prefer-dist --no-suggest --no-autoloader
+  - |
+    if [[ ! -z "$COMPOSER_ARGS" ]]; then
+      composer install --prefer-dist --no-suggest --no-autoloader $COMPOSER_ARGS
+    fi
 
 script:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+* Lower the minimum version of [composer/installers](https://github.com/composer/installers) to `^1.0` ([#2]).
+
 ## [1.1.0] - 2018-04-14
 
 * Bypass the caching operation if a callback either throws an Exception or returns a `WP_Error` object ([#1]).
@@ -25,3 +29,4 @@ Initial public release of the package, including the following functions:
 [1.1.0]: https://github.com/stevegrunwell/wp-cache-remember/releases/tag/v1.1.0
 [1.0.0]: https://github.com/stevegrunwell/wp-cache-remember/releases/tag/v1.0.0
 [#1]: https://github.com/stevegrunwell/wp-cache-remember/pull/1
+[#2]: https://github.com/stevegrunwell/wp-cache-remember/issues/2

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.2",
-        "composer/installers": "^1.5"
+        "composer/installers": "^1.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bebf9e2b96bfad1fddb1d585c0c76395",
+    "content-hash": "20b6e39d276e55faa6462ddce04f5cca",
     "packages": [
         {
             "name": "composer/installers",
@@ -198,16 +198,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.2",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
+                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
+                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
                 "shasum": ""
             },
             "require": {
@@ -217,7 +217,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -245,7 +245,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-19T21:44:46+00:00"
+            "time": "2018-06-06T23:58:19+00:00"
         },
         {
             "name": "wimg/php-compatibility",


### PR DESCRIPTION
This PR lowers the required `composer/installers` version to `^1.0`, enabling a wider install base. Additionally, it adds a new job to Travis, checking with the lowest resolvable set of dependencies.

Fixes #2.