### PR TITLE
Travis: add builds to test against PHP 7.3-7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: php
 dist: trusty
 
@@ -12,12 +11,16 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.4
       env: WP_VERSION=trunk
-    - php: 7.2
+    - php: 7.4
       env: WP_VERSION=trunk COMPOSER_LOWEST=1
-    - php: 7.2
+    - php: 7.3
       env: WP_VERSION=latest RUN_PHPCS=1 RUN_CODE_COVERAGE=1
+    - php: 7.3
+      env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=latest
     - php: 7.1
       env: WP_VERSION=latest
     - php: 7.0
@@ -31,7 +34,7 @@ before_script:
       chmod +x coveralls.phar
       mkdir -p build/logs
     else
-      phpenv config-rm xdebug.ini
+      phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     fi
   - |
     if [[ ! -z "$WP_VERSION" ]]; then


### PR DESCRIPTION
Includes:
* Removing `sudo: false`. Sudo hasn't been supported on Travis for quite a while now.
* Making the _remove Xdebug_ command more stable when using recent PHP versions for which Xdebug may not be available yet.

Note: for now running code coverage on PHP 7.3 rather than PHP 7.4 as Xdebug has not been installed on the PHP 7.4 Travis image yet.